### PR TITLE
chore: use "reason" code block language tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ let default = ReasonReact.wrapReasonForJs(~component, jsProps => make(jsProps##c
 
 1.  Create your ReasonReact component (e.g. `Paragraph.re` shown below)
 
-    ```ml
+    ```reason
     let component = ReasonReact.statelessComponent("Paragraph");
 
     let make = children => {


### PR DESCRIPTION
This is to silence prism highlighter warnings -- `reason` is on the [list of officially supported language tags](https://prismjs.com/#languages-list). Thanks!